### PR TITLE
Optimizing $and queries in the root level

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,12 @@ let package = Package(
         .target(
             name: "MongoDBPredicateAdaptor",
             dependencies: []),
+        .testTarget(
+            name: "MongoDBPredicateAdaptorTests",
+            dependencies: [
+                "MongoDBPredicateAdaptor",
+            ]
+        ),
     ],
     swiftLanguageVersions: [.v4, .v4_2]
 )

--- a/Sources/MongoDBPredicateAdaptor/MongoDBPredicateAdaptor.swift
+++ b/Sources/MongoDBPredicateAdaptor/MongoDBPredicateAdaptor.swift
@@ -123,7 +123,7 @@ extension NSPredicate {
                 key == MongoDBOperator.and.rawValue,
                 let value = _value as? [[String : Any]],
                 let sequence = Optional(value.filter({ $0.count == 1 }).compactMap({ $0.first })),
-                value.count == sequence.count
+                value.count == Set(sequence.map{ $0.key }).count
             {
                 result = [String : Any](uniqueKeysWithValues: sequence)
             }

--- a/Sources/MongoDBPredicateAdaptor/MongoDBPredicateAdaptor.swift
+++ b/Sources/MongoDBPredicateAdaptor/MongoDBPredicateAdaptor.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if !os(watchOS)
+#if canImport(MapKit)
     import MapKit
 #endif
 
@@ -107,11 +107,26 @@ extension NSCompoundPredicate {
 extension NSPredicate {
     
     public var mongoDBQuery: [String : Any]? {
+        return mongoDBQuery()
+    }
+    
+    public func mongoDBQuery(optimize: Bool = true) -> [String : Any]? {
         var result: [String : Any]? = nil
         if let predicate = self as? NSComparisonPredicate {
             result = transform(comparisonPredicate: predicate)
         } else if let predicate = self as? NSCompoundPredicate {
             result = transform(compoundPredicate: predicate)
+            if optimize,
+                let _result = result,
+                _result.count == 1,
+                let (key, _value) = _result.first,
+                key == MongoDBOperator.and.rawValue,
+                let value = _value as? [[String : Any]],
+                let sequence = Optional(value.filter({ $0.count == 1 }).compactMap({ $0.first })),
+                value.count == sequence.count
+            {
+                result = [String : Any](uniqueKeysWithValues: sequence)
+            }
         }
         return result
     }
@@ -372,7 +387,7 @@ extension NSPredicate {
         } else if let set = constant as? NSSet {
             return set.allObjects
         }
-#if !os(watchOS)
+#if canImport(MapKit)
         if let shape = constant as? MKShape {
             `operator` = .geoIn
             return transform(geoShape: shape)
@@ -382,7 +397,7 @@ extension NSPredicate {
         return nil
     }
     
-    #if !os(watchOS)
+    #if canImport(MapKit)
     private func transform(geoShape: MKShape) -> [String : Any]? {
         if let circle = geoShape as? MKCircle {
             return [

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import MongoDBPredicateAdaptorTests
+
+var tests = [XCTestCaseEntry]()
+tests += MongoDBPredicateAdaptorTests.allTests()
+XCTMain(tests)

--- a/Tests/MongoDBPredicateAdaptorTests/MongoDBPredicateAdaptorTests.swift
+++ b/Tests/MongoDBPredicateAdaptorTests/MongoDBPredicateAdaptorTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import MongoDBPredicateAdaptor
+
+class MongoDBPredicateAdaptorTests: XCTestCase {
+    
+    func testAndNotOptimized() {
+        let predicate = NSPredicate(format: "name == %@ AND age > %@", "Victor", NSNumber(value: 18))
+        let _mongoDBQuery = predicate.mongoDBQuery(optimize: false)
+        guard let mongoDBQuery = _mongoDBQuery else {
+            XCTAssertNotNil(_mongoDBQuery)
+            return
+        }
+        XCTAssertEqual(mongoDBQuery.count, 1)
+        let _and = mongoDBQuery["$and"] as? [[String : Any]]
+        guard let and = _and else {
+            XCTAssertNotNil(_and)
+            return
+        }
+        XCTAssertEqual(and.count, 2)
+        XCTAssertEqual(and.filter({ $0.first?.key == "name" }).first?.values.first as? String, "Victor")
+        let _age = and.filter({ $0.first?.key == "age" }).first?.values.first as? [String : Any]
+        guard let age = _age else {
+            XCTAssertNotNil(_age)
+            return
+        }
+        XCTAssertEqual(age.count, 1)
+        XCTAssertEqual(age["$gt"] as? Int, 18)
+    }
+    
+    func testAndOptimized() {
+        let predicate = NSPredicate(format: "name == %@ AND age > %@", "Victor", NSNumber(value: 18))
+        let _mongoDBQuery = predicate.mongoDBQuery
+        guard let mongoDBQuery = _mongoDBQuery else {
+            XCTAssertNotNil(_mongoDBQuery)
+            return
+        }
+        XCTAssertEqual(mongoDBQuery.count, 2)
+        XCTAssertEqual(mongoDBQuery["name"] as? String, "Victor")
+        let _age = mongoDBQuery["age"] as? [String : Any]
+        guard let age = _age else {
+            XCTAssertNotNil(_age)
+            return
+        }
+        XCTAssertEqual(age.count, 1)
+        XCTAssertEqual(age["$gt"] as? Int, 18)
+    }
+
+    static var allTests = [
+        ("testAndNotOptimized", testAndNotOptimized),
+        ("testAndOptimized", testAndOptimized),
+    ]
+
+}

--- a/Tests/MongoDBPredicateAdaptorTests/XCTestManifests.swift
+++ b/Tests/MongoDBPredicateAdaptorTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(MongoDBPredicateAdaptorTests.allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
optimize queries like

```
{  
   "$and":[  
      {  
         "name":"Victor"
      },
      {  
         "age":18
      }
   ]
}
```

to become

```
{  
   "name":"Victor",
   "age":18
}
```